### PR TITLE
tmux: SSH越しのスクロールかくつきを軽減

### DIFF
--- a/.bin/.tmux.conf
+++ b/.bin/.tmux.conf
@@ -106,7 +106,7 @@ bind r source-file ~/.tmux.conf \; display-message "Config reloaded!"
 # -------------------------------------------
 setw -g mode-keys vi
 bind -T copy-mode-vi v send -X begin-selection
-# Rely on `set-clipboard on` to push the selection to the outer terminal via OSC 52.
+# Rely on `set-clipboard external` to push the selection to the outer terminal via OSC 52.
 bind -T copy-mode-vi y send -X copy-pipe-and-cancel
 bind -T copy-mode-vi Enter send -X copy-pipe-and-cancel
 

--- a/.bin/.tmux.conf
+++ b/.bin/.tmux.conf
@@ -13,6 +13,11 @@ set -g focus-events on
 set -sg escape-time 10
 setw -g aggressive-resize on
 
+# Forward yanked text to the outer terminal via OSC 52, so copy works
+# from iOS SSH clients (Blink/Termius/Prompt) and iTerm2 alike.
+set -g set-clipboard on
+set -as terminal-features ',xterm*:clipboard'
+
 # Locale: inherit from the parent shell to avoid mismatches
 set -g update-environment "LANG LC_ALL"
 
@@ -26,12 +31,12 @@ bind C-t send-prefix
 # -------------------------------------------
 # Mouse Support
 # -------------------------------------------
-set -g mouse on
-
-# Toggle mouse mode (off = native terminal scroll, smoother over SSH)
+# Default off so touch scrolling on iOS uses the client's native buffer.
+# Toggle with prefix + m when pane selection / wheel-driven copy mode is needed.
+set -g mouse off
 bind m set -g mouse \; display "mouse #{?mouse,on,off}"
 
-# Scroll multiple lines per wheel notch to reduce redraw events over SSH
+# When mouse is on, scroll multiple lines per wheel notch to reduce redraws over SSH
 bind -T copy-mode-vi WheelUpPane   send -X -N 3 scroll-up
 bind -T copy-mode-vi WheelDownPane send -X -N 3 scroll-down
 
@@ -45,20 +50,11 @@ set -g renumber-windows on
 # -------------------------------------------
 # Key Bindings - Window Management
 # -------------------------------------------
+# Window selection uses tmux's default `prefix + 1..9` since Alt is not
+# reliably sendable from iOS SSH clients.
 bind c new-window -c "#{pane_current_path}"
 bind n next-window
 bind p previous-window
-
-# Quick window switching with Alt+number
-bind -n M-1 select-window -t 1
-bind -n M-2 select-window -t 2
-bind -n M-3 select-window -t 3
-bind -n M-4 select-window -t 4
-bind -n M-5 select-window -t 5
-bind -n M-6 select-window -t 6
-bind -n M-7 select-window -t 7
-bind -n M-8 select-window -t 8
-bind -n M-9 select-window -t 9
 
 # -------------------------------------------
 # Key Bindings - Pane Management
@@ -86,13 +82,9 @@ bind -r J resize-pane -D 5
 bind -r K resize-pane -U 5
 bind -r L resize-pane -R 5
 
-# Layout switching
+# Layout switching: cycle with prefix + Space (Alt-based direct layout binds
+# removed because Alt is not reliably sendable from iOS clients).
 bind Space next-layout
-bind M-1 select-layout even-horizontal
-bind M-2 select-layout even-vertical
-bind M-3 select-layout main-horizontal
-bind M-4 select-layout main-vertical
-bind M-5 select-layout tiled
 
 # -------------------------------------------
 # Key Bindings - Session Management
@@ -109,8 +101,9 @@ bind r source-file ~/.tmux.conf \; display-message "Config reloaded!"
 # -------------------------------------------
 setw -g mode-keys vi
 bind -T copy-mode-vi v send -X begin-selection
-bind -T copy-mode-vi y send -X copy-pipe-and-cancel "pbcopy"
-bind -T copy-mode-vi Enter send -X copy-pipe-and-cancel "pbcopy"
+# Rely on `set-clipboard on` to push the selection to the outer terminal via OSC 52.
+bind -T copy-mode-vi y send -X copy-pipe-and-cancel
+bind -T copy-mode-vi Enter send -X copy-pipe-and-cancel
 
 # Quick copy mode entry with prefix + [
 bind [ copy-mode
@@ -134,9 +127,9 @@ set -g status-style 'bg=#1e1e2e fg=#cdd6f4'
 set -g status-left-length 30
 set -g status-left '#[fg=#1e1e2e,bg=#89b4fa,bold] #S #[fg=#89b4fa,bg=#1e1e2e]'
 
-# Right: Date and time
-set -g status-right-length 50
-set -g status-right '#[fg=#45475a]#[fg=#cdd6f4,bg=#45475a] %Y-%m-%d #[fg=#89b4fa]#[fg=#1e1e2e,bg=#89b4fa,bold] %H:%M '
+# Right: Date and time (compact for narrow iPhone screens)
+set -g status-right-length 30
+set -g status-right '#[fg=#45475a]#[fg=#cdd6f4,bg=#45475a] %m/%d #[fg=#89b4fa]#[fg=#1e1e2e,bg=#89b4fa,bold] %H:%M '
 
 # Window status
 setw -g window-status-format '#[fg=#6c7086] #I:#W '

--- a/.bin/.tmux.conf
+++ b/.bin/.tmux.conf
@@ -28,7 +28,12 @@ bind C-t send-prefix
 # -------------------------------------------
 set -g mouse on
 
-# Use tmux's default mouse behavior
+# Toggle mouse mode (off = native terminal scroll, smoother over SSH)
+bind m set -g mouse \; display "mouse #{?mouse,on,off}"
+
+# Scroll multiple lines per wheel notch to reduce redraw events over SSH
+bind -T copy-mode-vi WheelUpPane   send -X -N 3 scroll-up
+bind -T copy-mode-vi WheelDownPane send -X -N 3 scroll-down
 
 # -------------------------------------------
 # Window & Pane Index

--- a/.bin/.tmux.conf
+++ b/.bin/.tmux.conf
@@ -15,7 +15,10 @@ setw -g aggressive-resize on
 
 # Forward yanked text to the outer terminal via OSC 52, so copy works
 # from iOS SSH clients (Blink/Termius/Prompt) and iTerm2 alike.
-set -g set-clipboard on
+# `external` exports copy-mode yanks outward but ignores OSC 52 from apps
+# running inside tmux, which prevents in-tmux programs from silently
+# writing to the iOS clipboard.
+set -g set-clipboard external
 set -as terminal-features ',xterm*:clipboard'
 
 # Locale: inherit from the parent shell to avoid mismatches
@@ -32,7 +35,9 @@ bind C-t send-prefix
 # Mouse Support
 # -------------------------------------------
 # Default off so touch scrolling on iOS uses the client's native buffer.
-# Toggle with prefix + m when pane selection / wheel-driven copy mode is needed.
+# Toggle with prefix + m when pane selection / wheel-driven copy mode is
+# needed, or when running alternate-screen apps (vim/less/man) where the
+# client's native scrollback does not apply.
 set -g mouse off
 bind m set -g mouse \; display "mouse #{?mouse,on,off}"
 


### PR DESCRIPTION
- prefix+m でマウスモードのon/offをトグル可能に。offにすると
  ターミナルのネイティブスクロールが使えてSSH越しでなめらか
- copy-modeのホイール1ノッチで3行スクロールするように変更し、
  ネットワーク往復イベント数を削減

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SSH/iOS セッション向けのOSC52ベースクリップボード連携を追加しました。

* **Improvements**
  * コピー操作をより連携された方式に変更し、外部クリップボードへのコピーが改善されました。
  * マウス動作をデフォルトOFFにし、プレフィックスでトグル可能・マルチラインホイールをサポートしました。
  * Altベースのクイック選択/レイアウト選択を削減し、ショートカットを簡素化しました。
  * ステータスバーの日時表示を狭い画面向けに短縮しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cazuu/dotfiles/pull/2)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->