### PR TITLE
Add tmux layout toggle script for laptop/desktop workflows

### DIFF
--- a/.bin/.tmux-layout-toggle.sh
+++ b/.bin/.tmux-layout-toggle.sh
@@ -4,25 +4,21 @@
 #   - 1ウィンドウ複数ペインなら → 各ペインを別ウィンドウへ break-pane
 set -euo pipefail
 
-session=$(tmux display-message -p '#S')
-current_window_id=$(tmux display-message -p '#{window_id}')
-current_window=$(tmux display-message -p '#I')
-window_count=$(tmux list-windows -t "$session" | wc -l | tr -d ' ')
-pane_count=$(tmux list-panes -t "$session:$current_window" | wc -l | tr -d ' ')
+current_window=$(tmux display-message -p '#{window_id}')
+window_count=$(tmux display-message -p '#{session_windows}')
+pane_count=$(tmux display-message -p '#{window_panes}')
 
 if [ "$window_count" -gt 1 ]; then
-    for w in $(tmux list-windows -t "$session" -F '#{window_id}' \
-               | grep -v "^${current_window_id}$"); do
+    for w in $(tmux list-windows -F '#{window_id}' | grep -v "^${current_window}$"); do
         tmux join-pane -h -s "$w"
     done
-    tmux select-layout -t "$session:$current_window" even-horizontal
-    tmux display-message "merged: #{window_panes} panes in 1 window"
+    tmux select-layout -t "$current_window" even-horizontal
+    tmux display-message "merged into 1 window"
 elif [ "$pane_count" -gt 1 ]; then
-    while [ "$(tmux list-panes -t "$session:$current_window" | wc -l | tr -d ' ')" -gt 1 ]; do
-        last_pane=$(tmux list-panes -t "$session:$current_window" -F '#{pane_id}' | tail -n 1)
-        tmux break-pane -d -s "$last_pane"
+    for p in $(tmux list-panes -t "$current_window" -F '#{pane_id}' | tail -n +2); do
+        tmux break-pane -d -s "$p"
     done
-    tmux display-message "split: panes broken into separate windows"
+    tmux display-message "split into separate windows"
 else
-    tmux display-message "nothing to toggle (1 window, 1 pane)"
+    tmux display-message "nothing to toggle"
 fi

--- a/.bin/.tmux-layout-toggle.sh
+++ b/.bin/.tmux-layout-toggle.sh
@@ -1,21 +1,24 @@
 #!/usr/bin/env bash
 # Toggle between multi-window (laptop) and split-pane (desktop) layouts.
-#   - 複数ウィンドウがあれば → カレントウィンドウへ全部 join-pane してペイン分割
-#   - 1ウィンドウ複数ペインなら → 各ペインを別ウィンドウへ break-pane
+#   - 複数ウィンドウがあれば → カレントウィンドウへ全ペインを join-pane
+#   - 1ウィンドウ複数ペインなら → アクティブ以外を別ウィンドウへ break-pane
 set -euo pipefail
 
 current_window=$(tmux display-message -p '#{window_id}')
+current_pane=$(tmux display-message -p '#{pane_id}')
 window_count=$(tmux display-message -p '#{session_windows}')
 pane_count=$(tmux display-message -p '#{window_panes}')
 
 if [ "$window_count" -gt 1 ]; then
-    for w in $(tmux list-windows -F '#{window_id}' | grep -v "^${current_window}$"); do
-        tmux join-pane -h -s "$w"
+    for p in $(tmux list-panes -s -F '#{window_id} #{pane_id}' \
+               | awk -v cur="$current_window" '$1 != cur { print $2 }'); do
+        tmux join-pane -h -s "$p" -t "$current_window"
     done
     tmux select-layout -t "$current_window" even-horizontal
     tmux display-message "merged into 1 window"
 elif [ "$pane_count" -gt 1 ]; then
-    for p in $(tmux list-panes -t "$current_window" -F '#{pane_id}' | tail -n +2); do
+    for p in $(tmux list-panes -t "$current_window" -F '#{pane_id}' \
+               | grep -v "^${current_pane}$"); do
         tmux break-pane -d -s "$p"
     done
     tmux display-message "split into separate windows"

--- a/.bin/.tmux-layout-toggle.sh
+++ b/.bin/.tmux-layout-toggle.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Toggle between multi-window (laptop) and split-pane (desktop) layouts.
+#   - 複数ウィンドウがあれば → カレントウィンドウへ全部 join-pane してペイン分割
+#   - 1ウィンドウ複数ペインなら → 各ペインを別ウィンドウへ break-pane
+set -euo pipefail
+
+session=$(tmux display-message -p '#S')
+current_window_id=$(tmux display-message -p '#{window_id}')
+current_window=$(tmux display-message -p '#I')
+window_count=$(tmux list-windows -t "$session" | wc -l | tr -d ' ')
+pane_count=$(tmux list-panes -t "$session:$current_window" | wc -l | tr -d ' ')
+
+if [ "$window_count" -gt 1 ]; then
+    for w in $(tmux list-windows -t "$session" -F '#{window_id}' \
+               | grep -v "^${current_window_id}$"); do
+        tmux join-pane -h -s "$w"
+    done
+    tmux select-layout -t "$session:$current_window" even-horizontal
+    tmux display-message "merged: #{window_panes} panes in 1 window"
+elif [ "$pane_count" -gt 1 ]; then
+    while [ "$(tmux list-panes -t "$session:$current_window" | wc -l | tr -d ' ')" -gt 1 ]; do
+        last_pane=$(tmux list-panes -t "$session:$current_window" -F '#{pane_id}' | tail -n 1)
+        tmux break-pane -d -s "$last_pane"
+    done
+    tmux display-message "split: panes broken into separate windows"
+else
+    tmux display-message "nothing to toggle (1 window, 1 pane)"
+fi

--- a/.bin/.tmux.conf
+++ b/.bin/.tmux.conf
@@ -91,6 +91,9 @@ bind -r L resize-pane -R 5
 # removed because Alt is not reliably sendable from iOS clients).
 bind Space next-layout
 
+# Toggle: multi-window (laptop) <-> single-window split-pane (desktop)
+bind T run-shell "~/.tmux-layout-toggle.sh"
+
 # -------------------------------------------
 # Key Bindings - Session Management
 # -------------------------------------------

--- a/.bin/.tmux.conf
+++ b/.bin/.tmux.conf
@@ -92,7 +92,7 @@ bind -r L resize-pane -R 5
 bind Space next-layout
 
 # Toggle: multi-window (laptop) <-> single-window split-pane (desktop)
-bind T run-shell "~/.tmux-layout-toggle.sh"
+bind t run-shell "~/.tmux-layout-toggle.sh"
 
 # -------------------------------------------
 # Key Bindings - Session Management

--- a/.bin/.tmux.conf
+++ b/.bin/.tmux.conf
@@ -92,7 +92,7 @@ bind -r L resize-pane -R 5
 bind Space next-layout
 
 # Toggle: multi-window (laptop) <-> single-window split-pane (desktop)
-bind t run-shell "~/.tmux-layout-toggle.sh"
+bind t run-shell "$HOME/.tmux-layout-toggle.sh"
 
 # -------------------------------------------
 # Key Bindings - Session Management


### PR DESCRIPTION
## Summary
Added a new tmux layout toggle feature that switches between multi-window (laptop) and split-pane (desktop) layouts, along with a keybinding to trigger it.

## Key Changes
- **New script**: `.bin/.tmux-layout-toggle.sh` - Intelligently toggles between two tmux layout modes:
  - Multi-window mode → Single window with split panes (horizontal layout)
  - Single window with multiple panes → Separate windows
  - Single window with single pane → No-op with informational message
- **Updated config**: Added `bind t` keybinding in `.tmux.conf` to invoke the toggle script

## Implementation Details
The toggle script uses tmux commands to:
- Detect current window/pane configuration via `display-message`
- Use `join-pane` to merge windows into the current window with horizontal split layout
- Use `break-pane` to split panes into separate windows
- Provide user feedback via `display-message` for each operation

This enables seamless switching between laptop workflows (multiple windows) and desktop workflows (single window with panes).

https://claude.ai/code/session_01MJYKPheLBWFTEGrrMnZsnv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * tmuxでマルチウィンドウレイアウトとシングルウィンドウ分割レイアウトをワンタッチで切り替えるショートカット（prefix + t）を追加しました。
  * 切り替えを行う小さなスクリプトを導入し、ウィンドウ／ペイン構成に応じて自動で処理します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->